### PR TITLE
Add filter to allow customization of folder attribute

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Added filter gravityflowfolders_display_folder to allow the folder shortcode argument to be customized.

--- a/includes/class-folders-page.php
+++ b/includes/class-folders-page.php
@@ -27,7 +27,17 @@ class Gravity_Flow_Folders_Page {
 		}
 
 		if ( ! empty( $args['folder'] ) ) {
-			$folder_id = $args['folder'];
+			/**
+			 * Purpose of the filter
+			 *
+			 * @since 1.4
+			 *
+			 * @param string Folder name / ID from shortcode arguments
+			 * @param array  Shortcode arguments
+			 *
+			 * @return string
+			 */
+			$folder_id = apply_filters( 'gravityflowfolders_display_folder', $args['folder'], $args );
 
 			$folder = gravity_flow_folders()->get_folder( $folder_id, $user );
 			if ( $folder ) {

--- a/includes/class-folders-page.php
+++ b/includes/class-folders-page.php
@@ -33,9 +33,9 @@ class Gravity_Flow_Folders_Page {
 			 *
 			 * @since 1.4
 			 *
-			 * @param string $folder_id Folder name / ID from shortcode arguments
-			 * @param array  $args      Shortcode arguments
-			 * @param object $user      User to render folder entries for - specified by $args or wp_get_current_user
+			 * @param string  $folder_id Folder name / ID from shortcode arguments
+			 * @param array   $args      Shortcode arguments
+			 * @param WP_User $user      User to render folder entries for - specified by $args or wp_get_current_user
 			 *
 			 * @return string
 			 */

--- a/includes/class-folders-page.php
+++ b/includes/class-folders-page.php
@@ -27,17 +27,19 @@ class Gravity_Flow_Folders_Page {
 		}
 
 		if ( ! empty( $args['folder'] ) ) {
+			$folder_id = $args['folder'];
 			/**
-			 * Purpose of the filter
+			 * Allow customization of which folder is rendered
 			 *
 			 * @since 1.4
 			 *
-			 * @param string Folder name / ID from shortcode arguments
-			 * @param array  Shortcode arguments
+			 * @param string $folder_id Folder name / ID from shortcode arguments
+			 * @param array  $args      Shortcode arguments
+			 * @param object $user      User to render folder entries for - specified by $args or wp_get_current_user
 			 *
 			 * @return string
 			 */
-			$folder_id = apply_filters( 'gravityflowfolders_display_folder', $args['folder'], $args );
+			$folder_id = apply_filters( 'gravityflowfolders_render_folder_id', $folder_id, $args, $user );
 
 			$folder = gravity_flow_folders()->get_folder( $folder_id, $user );
 			if ( $folder ) {


### PR DESCRIPTION
See [HS #9925](https://secure.helpscout.net/conversation/894071953/9925?folderId=1776095) seeking to allow a method to customize the [folder attribute of the shortcode](https://docs.gravityflow.io/article/124-folders-extension).

This branch adds a filter gravityflowfolders_display_folder which enables custom code. Immediate use case was to retrieve a value from user meta that matches to folder ID.

**Test Instructions**
- Create multiple folders in Workflow > Settings (Recommend naming 1 - 10)
- Create a form that assigns entries to different folders.
- Add code similar to the following (changing based on folder names)
```
add_filter( 'gravityflowfolders_display_folder', 'sh_display_folder_dynamic', 10, 2 );
function sh_display_folder_dynamic( $folder_id, $args ) {
	if ( $folder_id == 'dynamic-user-level' ) {
		$current_user = wp_get_current_user();
		if ( $current_user->exists() ) {
			$level = get_user_meta( $current_user->ID, 'wp_user_level', true );
			if ( ! empty( $level ) ) {
				return $level;
			}
			return $folder_id;
		}
	}
	return $folder_id;
}
```
- Use the shortcode with [gravityflow page="folders" folder="dynamic-user-level"] and verify that entries into the associated folder are correctly displayed.