### PR TITLE
Fix RTL Workflow Folder Settings

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fix an issue with the RTL Languages not displaying folders correctly in Workflow Folder Settings. 

--- a/js/components/repeater/repeater.js
+++ b/js/components/repeater/repeater.js
@@ -116,7 +116,7 @@ export default class Repeater extends React.Component {
 							{removeButton}
 						</div>
 
-						<br style={{clear: 'left'}} />
+						<br style={{clear: 'both'}} />
 					</div>
 				)
 			});

--- a/js/folder-settings-build.js
+++ b/js/folder-settings-build.js
@@ -485,7 +485,7 @@ var Repeater = function (_React$Component) {
 							_react2.default.createElement('i', { onClick: _this2._addItem.bind(_this2, index), className: 'gficon-add' }),
 							removeButton
 						),
-						_react2.default.createElement('br', { style: { clear: 'left' } })
+						_react2.default.createElement('br', { style: { clear: 'both' } })
 					);
 				});
 			}


### PR DESCRIPTION
## Description
Re: [HS# 15610](https://secure.helpscout.net/conversation/1355570030/15610?folderId=1113492#thread-3909379177)
An issue with the RTL languages (like Arabic) not displaying the workflow folder settings correctly.


## Testing instructions
1. Create folders.
2. Switch the site to Arabic.
3. Go-to Workflow -> Settings ->Folders.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->
